### PR TITLE
fix global-stack-root is deprecated

### DIFF
--- a/src/HsDev/Stack.hs
+++ b/src/HsDev/Stack.hs
@@ -108,7 +108,7 @@ makeLenses ''StackEnv
 
 getStackEnv :: Paths -> Maybe StackEnv
 getStackEnv p = StackEnv <$>
-	(p ^. pathOf "global-stack-root") <*>
+	(p ^. pathOf "stack-root") <*>
 	(p ^. pathOf "project-root") <*>
 	(p ^. pathOf "config-location") <*>
 	(p ^. pathOf "ghc-paths") <*>


### PR DESCRIPTION
The 'global-stack-root' is deprecated and don't work in stack 1.1.2

'--global-stack-root' will be removed in a future release. Please use '--stack-root' instead.

When using 'global-stack-root', hsdev produces errors like "tool 'stack' failed: can't get paths" and doesn't work properly.

So, this PR changes 'global-stack-root' to 'stack-root' as it proposed by stack. Tested with this change - hsdev now works as expected.
