### PR TITLE
Make server listen locally

### DIFF
--- a/src/HsDev/Server/Commands.hs
+++ b/src/HsDev/Server/Commands.hs
@@ -163,7 +163,7 @@ runServerCommand (Run sopts) = runServer sopts $ do
 		bracket (liftIO $ makeSocket (serverPort sopts)) (liftIO . close) $ \s -> do
 			liftIO $ do
 				setSocketOption s ReuseAddr 1
-				bind s $ sockAddr (serverPort sopts) iNADDR_ANY
+				bind s (sockAddr (serverPort sopts) (tupleToHostAddress (127, 0, 0, 1)))
 				listen s maxListenQueue
 			forever $ logAsync (Log.log Log.Fatal . fromString) $ logIO "exception: " (Log.log Log.Error . fromString) $ do
 				Log.log Log.Trace "accepting connection"


### PR DESCRIPTION
To avoid any risks, listen locally only.
Maybe add a command-line option later on.