### PR TITLE
add stack.yaml for building with haskell-stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist
 *.log
 *.*~
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-8.6
+packages:
+- '.'
+extra-deps:
+- aeson-lens-0.5.0.0
+- haddock-api-2.17.3.1
+- hdocs-0.5.2.0


### PR DESCRIPTION
For folks who installed `stack` but no `cabal`, this can make installation easier.