### PR TITLE
Fix compilation using stack.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - aeson-lens-0.5.0.0
 - haddock-api-2.17.3.1
 - hdocs-0.5.2.0
-- hformat-0.2.0.0
-- simple-log-0.8.3
-- text-region-0.2.0.0
+- hformat-0.3.0.0
+- simple-log-0.9.2
+- text-region-0.3.0.0
 resolver: lts-8.12


### PR DESCRIPTION
Currently `stack build` fails due to version incompatibilities. Bump some dependency versions to get it compiling. 